### PR TITLE
Added support for ANSI color in watched command output lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e348dcd256ba06d44d5deabc88a7c0e80ee7303158253ca069bcd9e9b7f57"
+dependencies = [
+ "nom",
+ "ratatui",
+ "thiserror",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -114,6 +167,7 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
 ]
@@ -135,6 +189,12 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crossterm"
@@ -394,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +478,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -775,6 +851,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +999,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 name = "watchbind"
 version = "0.1.19"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "clap",
  "crossterm 0.27.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/fritzrehde/watchbind"
 description = "A CLI menu for periodically watching a program's output and executing commands on its lines through keybindings"
 
 [dependencies]
-clap = { version = "4.4.7", default-features = false, features = ["std", "help", "cargo", "derive", "error-context"] }
+clap = { version = "4.4.7", default-features = false, features = ["std", "help", "cargo", "derive", "error-context", "string", "color"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 toml = { version = "0.7.8", default-features = false, features = ["parse"] }
 ratatui = "0.22.0"
@@ -18,7 +18,7 @@ crossterm = { version = "0.27", features = ["events", "event-stream"] }
 itertools = "0.11.0"
 anyhow = "1.0.75"
 indoc = "2.0.4"
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into_iterator", "as_ref"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "into_iterator", "as_ref"] }
 tabwriter = "1.3.0"
 parse-display = "0.8.2"
 derive-new = "0.5.9"
@@ -28,6 +28,7 @@ ranges = "0.3.3"
 # TODO: maybe we don't need all tokio and futures features, try to reduce
 tokio = { version = "1.33.0", features = ["full"] }
 futures = "0.3.29"
+ansi-to-tui = "3.1.0"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - [Installation](#installation)
 - [Customizations](#customizations)
   - [Keybindings](#customizations)
-  - [Formatting with Field Separators and Selections](#formatting-with-field-separators-and-selections)
+  - [Formatting with Field Separators and Field Selections](#formatting-with-field-separators-and-field-selections)
   - [Styling](#styling)
 - [Tips](#tips)
 
@@ -157,10 +157,9 @@ tab
 
 #### Operations
 
+<!-- TODO: Make table of toml config reference name,example,description -->
+
 All supported `OP` values:
-
-<!-- Make table of toml config reference name,example,description -->
-
 
 Operation | Description
 :-- | :--
@@ -186,7 +185,7 @@ The environment variable `lines` set to all selected lines, or if none are selec
 All set environment variables `ENV` will be made available in all future spawned commands/processes, including the watched command, any executed subcommands, as well as commands executed in `set-env` operations.
 If multiple lines are selected, they will be separated by newlines in `lines`.
 
-### Formatting with Field Separators and Selections
+### Formatting with Field Separators and Field Selections
 
 `watchbind` supports some extra formatting features reminiscent of the Unix `cut` command:
 
@@ -203,13 +202,19 @@ For instance, the field selection `1,3-4,6-` will display the first, third and f
 
 ### Styling
 
-Foreground colors, background colors and boldness of the line the cursor is on, the header lines and all other lines can be customized.
+Foreground colors, background colors and boldness can be customized.
+These styling options are available for:
+- The line the cursor is currently on with `cursor-[fg|bg|boldness]`.
+- The header lines with `header-[fg|bg|boldness]`.
+- All other lines with `non-cursor-non-header-[fg|bg|boldness]`.
+- The selection indicator with `selected-bg`.
 
-To see all available fields you can customize, run `watchbind -h`.
 The names of the customization fields from the command-line options (e.g. `--cursor-fg blue`) are the same in the TOML config file (e.g. `cursor-fg = "blue"`).
 
+Furthermore, `watchbind` also supports styling according to ANSI codes in the input text.
+
 All supported `COLOR` values:
-```
+```sh
 white
 black
 red
@@ -226,6 +231,15 @@ light_yellow
 light_blue
 light_magenta
 light_cyan
+reset        # Reset the fg and bg
+unspecified  # Don't applying any styling => use style from ANSI input text
+```
+
+All supported `BOLDNESS` values:
+```sh
+bold         # Make everything bold
+non-bold     # Make sure nothing is bold (i.e. remove any bold styling from input ANSI)
+unspecified  # Don't applying any styling => use style from ANSI input text
 ```
 
 ## Tips

--- a/examples/fields.toml
+++ b/examples/fields.toml
@@ -2,11 +2,10 @@ watched-command = """
 printf \
 "id,col1,col2,col3
 123,v1,v2,v3
-456,v4,v5,v6"
+456,v4,v5,v6
+789,v7,v8,v9"
 """
 interval = 5.0
-header-lines = 1
+header-lines = 2
 field-separator = ","
 fields = "1,3-4"
-
-[keybindings]

--- a/examples/ls.toml
+++ b/examples/ls.toml
@@ -1,11 +1,17 @@
 watched-command = "ls"
 interval = 3.0
-bold = false
-cursor-fg = "black"
+
+# cursor line
 cursor-bg = "blue"
-cursor-bold = true
-selected-bg = "red"
+cursor-boldness = "bold"
+
+# header lines
 header-lines = 1
+header-fg = "blue"
+header-boldness = "non-bold"
+
+# selected lines
+selected-bg = "red"
 
 [keybindings]
 "esc" = [ "unselect-all", "help-hide" ]

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,8 +40,8 @@ pub struct Interruptible {
 }
 
 // Advantages of the Type-State Builder Pattern:
-// 1. We don't have any option/enum (an alternative configuration strategy)
-// checking overhead at runtime.
+// 1. We don't have any option/enum checking (an alternative configuration
+// strategy) overhead at runtime.
 // 2. We can guarantee that we handled all possible Command "variants"
 // (combination of config options), that we use, at compile-time.
 // 3. Arguably, this also results in separated, cleaner code.
@@ -50,7 +50,6 @@ pub struct Interruptible {
 /// environment variables, whether the output is captured and whether the
 /// execution can be interrupted. Utilizes the type-state builder pattern to
 /// enforce these configurations at compile-time.
-// #[derive(Clone)]
 pub struct CommandBuilder<B = NonBlocking, E = WithoutEnv, O = NoOutput, I = NonInterruptible> {
     command: String,
     blocking: B,

--- a/src/config/fields/mod.rs
+++ b/src/config/fields/mod.rs
@@ -32,10 +32,12 @@ impl Fields {
     }
 }
 
-/// Format a string as a table that has its fields separated by an elastic
-/// tabstop, and only displays the fields that should be selected.
-/// Only applies any formatting if a separator or selection is present.
 pub trait TableFormatter {
+    /// Format a string as a table that has its fields separated by an elastic
+    /// tabstop, and only displays the fields that should be selected.
+    /// Only applies any formatting if a field separator or a field selection
+    /// are present.
+    /// Returns `None` if no formatting was applied.
     fn format_as_table(&self, fields: &Fields) -> Result<Option<String>>;
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ mod keybindings;
 mod style;
 
 pub use fields::{Fields, TableFormatter};
+use itertools::Itertools;
 pub use keybindings::{
     KeyEvent, Keybindings, Operation, OperationParsed, Operations, OperationsParsed,
 };
@@ -10,11 +11,14 @@ pub use style::Styles;
 
 use self::fields::{FieldSelections, FieldSeparator};
 use self::keybindings::{KeybindingsParsed, StringKeybindings};
+use self::style::{Boldness, Color, Style};
 use anyhow::{bail, Context, Result};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use indoc::indoc;
 use serde::Deserialize;
 use std::{fs::read_to_string, path::PathBuf, time::Duration};
+
+// TODO: don't have public members
 
 pub struct Config {
     pub log_file: Option<PathBuf>,
@@ -24,7 +28,6 @@ pub struct Config {
     pub keybindings_parsed: KeybindingsParsed,
     pub header_lines: usize,
     pub fields: Fields,
-    // pub initial_env_variables: Vec<String>,
     pub initial_env_variables: OperationsParsed,
 }
 
@@ -45,6 +48,32 @@ impl TryFrom<TomlConfig> for Config {
     type Error = anyhow::Error;
     fn try_from(toml: TomlConfig) -> Result<Self, Self::Error> {
         let default = TomlConfig::default();
+
+        let non_cursor_style = Style::new(
+            toml.non_cursor_non_header_fg
+                .or(default.non_cursor_non_header_fg),
+            toml.non_cursor_non_header_bg
+                .or(default.non_cursor_non_header_bg),
+            toml.non_cursor_non_header_boldness
+                .or(default.non_cursor_non_header_boldness),
+        );
+        let cursor_style = Style::new(
+            toml.cursor_fg.or(default.cursor_fg),
+            toml.cursor_bg.or(default.cursor_bg),
+            toml.cursor_boldness.or(default.cursor_boldness),
+        );
+        let header_style = Style::new(
+            toml.header_fg.or(default.header_fg),
+            toml.header_bg.or(default.header_bg),
+            toml.header_boldness.or(default.header_boldness),
+        );
+        let selected_style = Style::new(
+            Color::Unspecified,
+            toml.selected_bg.or(default.selected_bg),
+            Boldness::Unspecified,
+        );
+        let styles = Styles::new(non_cursor_style, cursor_style, header_style, selected_style);
+
         Ok(Self {
             log_file: toml.log_file,
             initial_env_variables: toml.initial_env_variables.unwrap_or_default().try_into()?,
@@ -55,18 +84,7 @@ impl TryFrom<TomlConfig> for Config {
             watch_rate: Duration::from_secs_f64(
                 toml.interval.or(default.interval).expect("default"),
             ),
-            styles: Styles::parse(
-                toml.fg.or(default.fg),
-                toml.bg.or(default.bg),
-                toml.bold.or(default.bold),
-                toml.cursor_fg.or(default.cursor_fg),
-                toml.cursor_bg.or(default.cursor_bg),
-                toml.cursor_bold.or(default.cursor_bold),
-                toml.header_fg.or(default.header_fg),
-                toml.header_bg.or(default.header_bg),
-                toml.header_bold.or(default.header_bold),
-                toml.selected_bg.or(default.selected_bg),
-            )?,
+            styles,
             keybindings_parsed: StringKeybindings::merge(toml.keybindings, default.keybindings)
                 .expect("default")
                 .try_into()?,
@@ -77,50 +95,44 @@ impl TryFrom<TomlConfig> for Config {
 }
 
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct TomlConfig {
     log_file: Option<PathBuf>,
 
     #[serde(rename = "initial-env")]
     initial_env_variables: Option<Vec<String>>,
 
-    #[serde(rename = "watched-command")]
     watched_command: Option<String>,
-
     interval: Option<f64>,
-    fg: Option<String>,
-    bg: Option<String>,
-    bold: Option<bool>,
 
-    #[serde(rename = "cursor-fg")]
-    cursor_fg: Option<String>,
+    #[serde(default)]
+    cursor_fg: Color,
+    #[serde(default)]
+    cursor_bg: Color,
+    #[serde(default)]
+    cursor_boldness: Boldness,
 
-    #[serde(rename = "cursor-bg")]
-    cursor_bg: Option<String>,
-
-    #[serde(rename = "cursor-bold")]
-    cursor_bold: Option<bool>,
-
-    #[serde(rename = "header-fg")]
-    header_fg: Option<String>,
-
-    #[serde(rename = "header-bg")]
-    header_bg: Option<String>,
-
-    #[serde(rename = "header-bold")]
-    header_bold: Option<bool>,
-
-    #[serde(rename = "selected-bg")]
-    selected_bg: Option<String>,
-
-    #[serde(rename = "header-lines")]
     header_lines: Option<usize>,
+    #[serde(default)]
+    header_fg: Color,
+    #[serde(default)]
+    header_bg: Color,
+    #[serde(default)]
+    header_boldness: Boldness,
 
-    #[serde(rename = "field-separator")]
-    field_separator: Option<FieldSeparator>,
+    #[serde(default)]
+    non_cursor_non_header_fg: Color,
+    #[serde(default)]
+    non_cursor_non_header_bg: Color,
+    #[serde(default)]
+    non_cursor_non_header_boldness: Boldness,
+
+    #[serde(default)]
+    selected_bg: Color,
 
     #[serde(rename = "fields")]
     field_selections: Option<FieldSelections>,
+    field_separator: Option<FieldSeparator>,
 
     keybindings: Option<StringKeybindings>,
 }
@@ -135,22 +147,28 @@ impl TomlConfig {
         Ok(config)
     }
 
-    // self is favored
+    // Merge two configs, where `self` is favored.
     fn merge(self, other: Self) -> Self {
         Self {
             log_file: self.log_file.or(other.log_file),
             initial_env_variables: self.initial_env_variables.or(other.initial_env_variables),
             watched_command: self.watched_command.or(other.watched_command),
             interval: self.interval.or(other.interval),
-            fg: self.fg.or(other.fg),
-            bg: self.bg.or(other.bg),
-            bold: self.bold.or(other.bold),
+            non_cursor_non_header_fg: self
+                .non_cursor_non_header_fg
+                .or(other.non_cursor_non_header_fg),
+            non_cursor_non_header_bg: self
+                .non_cursor_non_header_bg
+                .or(other.non_cursor_non_header_bg),
+            non_cursor_non_header_boldness: self
+                .non_cursor_non_header_boldness
+                .or(other.non_cursor_non_header_boldness),
             cursor_fg: self.cursor_fg.or(other.cursor_fg),
             cursor_bg: self.cursor_bg.or(other.cursor_bg),
-            cursor_bold: self.cursor_bold.or(other.cursor_bold),
+            cursor_boldness: self.cursor_boldness.or(other.cursor_boldness),
             header_fg: self.header_fg.or(other.header_fg),
             header_bg: self.header_bg.or(other.header_bg),
-            header_bold: self.header_bold.or(other.header_bold),
+            header_boldness: self.header_boldness.or(other.header_boldness),
             selected_bg: self.selected_bg.or(other.selected_bg),
             header_lines: self.header_lines.or(other.header_lines),
             field_separator: self.field_separator.or(other.field_separator),
@@ -167,15 +185,15 @@ impl From<ClapConfig> for TomlConfig {
             initial_env_variables: clap.initial_env_variables,
             watched_command: clap.watched_command.map(|s| s.join(" ")),
             interval: clap.interval,
-            fg: clap.fg,
-            bg: clap.bg,
-            bold: clap.bold,
+            non_cursor_non_header_fg: clap.non_cursor_non_header_fg,
+            non_cursor_non_header_bg: clap.non_cursor_non_header_bg,
+            non_cursor_non_header_boldness: clap.non_cursor_non_header_boldness,
             cursor_fg: clap.cursor_fg,
             cursor_bg: clap.cursor_bg,
-            cursor_bold: clap.cursor_bold,
+            cursor_boldness: clap.cursor_boldness,
             header_fg: clap.header_fg,
             header_bg: clap.header_bg,
-            header_bold: clap.header_bold,
+            header_boldness: clap.header_boldness,
             selected_bg: clap.selected_bg,
             header_lines: clap.header_lines,
             field_separator: clap.field_separator,
@@ -188,12 +206,20 @@ impl From<ClapConfig> for TomlConfig {
 impl Default for TomlConfig {
     fn default() -> Self {
         let toml = indoc! {r#"
-			"interval" = 5.0
-			"bold" = false
-			"cursor-fg" = "black"
-			"cursor-bg" = "blue"
-			"cursor-bold" = true
+			"interval" = 3.0
+
+			"cursor-fg" = "unspecified"
+			"cursor-bg" = "gray"
+			"cursor-boldness" = "bold"
+
 			"header-fg" = "blue"
+			"header-bg" = "unspecified"
+			"header-boldness" = "non-bold"
+
+			"non-cursor-non-header-fg" = "unspecified"
+			"non-cursor-non-header-bg" = "unspecified"
+			"non-cursor-non-header-boldness" = "unspecified"
+
 			"selected-bg" = "magenta"
 
 			[keybindings]
@@ -216,7 +242,7 @@ impl Default for TomlConfig {
 }
 
 #[derive(Parser)]
-#[clap(version, about)]
+#[command(version, about, rename_all = "kebab-case", after_help = Self::all_possible_values())]
 pub struct ClapConfig {
     /// Enable logging, and write logs to file.
     #[arg(short, long, value_name = "FILE")]
@@ -234,65 +260,150 @@ pub struct ClapConfig {
     #[arg(short, long, value_name = "FILE")]
     config_file: Option<String>,
 
-    /// Seconds to wait between updates, 0 only executes once
-    #[arg(short, long, value_name = "SECS")]
+    /// Seconds (f64) to wait between updates, 0 only executes once
+    #[arg(short, long, value_name = "SECONDS")]
     interval: Option<f64>,
 
-    /// Foreground color of all lines except cursor
-    #[arg(long, value_name = "COLOR")]
-    fg: Option<String>,
+    /// Foreground color of cursor line
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    cursor_fg: Color,
 
-    /// Background color of all lines except cursor
-    #[arg(long, value_name = "COLOR")]
-    bg: Option<String>,
+    /// Background color of cursor line
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    cursor_bg: Color,
 
-    /// Text on all lines except the cursor's line are bold
-    #[arg(long, value_name = "BOOL")]
-    bold: Option<bool>,
-
-    /// Foreground color of cursor
-    #[arg(long = "cursor-fg", value_name = "COLOR")]
-    cursor_fg: Option<String>,
-
-    /// Background color of cursor
-    #[arg(long = "cursor-bg", value_name = "COLOR")]
-    cursor_bg: Option<String>,
-
-    /// Text on cursor's line is bold
-    #[arg(long = "cursor-bold", value_name = "BOOL")]
-    cursor_bold: Option<bool>,
+    /// Boldness of cursor line
+    #[arg(
+        long,
+        value_name = "BOLDNESS",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    cursor_boldness: Boldness,
 
     /// Foreground color of header lines
-    #[arg(long = "header-fg", value_name = "COLOR")]
-    header_fg: Option<String>,
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    header_fg: Color,
 
     /// Background color of header lines
-    #[arg(long = "header-bg", value_name = "COLOR")]
-    header_bg: Option<String>,
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    header_bg: Color,
 
-    /// Text on header line is bold
-    #[arg(long = "header-bold", value_name = "BOOL")]
-    header_bold: Option<bool>,
+    /// Boldness of header lines
+    #[arg(
+        long,
+        value_name = "BOLDNESS",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    header_boldness: Boldness,
 
-    /// Background color of selected line marker
-    #[arg(long = "selected-bg", value_name = "COLOR")]
-    selected_bg: Option<String>,
+    /// Foreground color of non-cursor, non-header lines.
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    non_cursor_non_header_fg: Color,
+
+    /// Background color of non-cursor, non-header lines.
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    non_cursor_non_header_bg: Color,
+
+    /// Boldness of non-cursor, non-header lines.
+    #[arg(
+        long,
+        value_name = "BOLDNESS",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    non_cursor_non_header_boldness: Boldness,
+
+    /// Background color of selected line indicator
+    #[arg(
+        long,
+        value_name = "COLOR",
+        default_value_t,
+        hide_default_value = true,
+        hide_possible_values = true
+    )]
+    selected_bg: Color,
 
     /// The first N lines of the input are treated as a sticky header
-    #[arg(long = "header-lines", value_name = "N")]
+    #[arg(long, value_name = "N")]
     header_lines: Option<usize>,
 
-    /// Field separator [possible values: any string]
-    #[arg(short = 's', long = "field-separator", value_name = "STRING")]
+    /// Field separator
+    #[arg(short = 's', long, value_name = "STRING")]
     field_separator: Option<FieldSeparator>,
 
-    /// Field selections/ranges (comma-separated), e.g., `X`, `X-Y`, `X-` (field indexes start at 1).
+    /// Comma-separated field selections/ranges, e.g. `X`, `X-Y`, `X-` (field indexes start at 1).
     #[arg(short = 'f', long = "fields", value_name = "LIST")]
     field_selections: Option<FieldSelections>,
 
     // TODO: replace with StringKeybindings once clap supports parsing into HashMap
     // TODO: known clap bug: replace with ClapKeybindings once supported
-    /// Keybindings as comma-separated `KEY:OP[+OP]*` pairs, e.g., `q:select+exit,r:reload`.
+    /// Keybindings as comma-separated `KEY:OP[+OP]*` pairs, e.g. `q:select+exit,r:reload`.
     #[arg(short = 'b', long = "bind", value_name = "LIST", value_delimiter = ',', value_parser = keybindings::parse_str)]
     keybindings: Option<Vec<(String, Vec<String>)>>,
+}
+
+/// Get string list of all possible values of `T`.
+fn get_possible_values<T: ValueEnum>() -> String {
+    T::value_variants()
+        .iter()
+        .filter_map(T::to_possible_value)
+        .map(|v| v.get_name().to_owned())
+        .join(", ")
+}
+
+impl ClapConfig {
+    /// Get printable help menu for possible values of `Color` and `Boldness`.
+    fn all_possible_values() -> String {
+        let possible_color_values = get_possible_values::<Color>();
+        let possible_boldness_values = get_possible_values::<Boldness>();
+        format!(
+            indoc! {r#"
+        Possible values:
+          COLOR:    [{}]
+          BOLDNESS: [{}]
+        "#},
+            possible_color_values, possible_boldness_values
+        )
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,10 @@ mod command;
 mod config;
 mod ui;
 
-use std::fs::File;
-
 use crate::config::Config;
 use anyhow::{Context, Result};
 use simplelog::{LevelFilter, WriteLogger};
+use std::fs::File;
 use ui::UI;
 
 #[tokio::main]

--- a/src/ui/state/lines/line.rs
+++ b/src/ui/state/lines/line.rs
@@ -1,30 +1,107 @@
-use ratatui::{style::Style, widgets::Cell};
+use ansi_to_tui::IntoText;
+use anyhow::Result;
+use itertools::Itertools;
+use ratatui::{style::Style, text::Text, widgets::Cell};
 
 pub struct Line {
+    /// Unformatted string that has any ANSI escape codes stripped out.
+    /// This string will be made available to the user's command's subshell
+    /// through an environment variable.
     unformatted: String,
-    formatted: Option<String>,
-    style: Style,
+    /// The text string that contains the string content, is formatted
+    /// according to the user's field separator, and is styled according to any
+    /// ANSI codes. Does not contain the user style. Immutable for the lifetime
+    /// of the line.
+    displayed_text: Text<'static>,
+    /// A cell containing the `displayed_text`, but with any user styles (style
+    /// settings that should apply to the whole line), provided at creation
+    /// and/or later, applied. If there is overlap in a setting between the
+    /// `displayed_text`s style and the user style, the user style is
+    /// prioritized.
+    displayed: Cell<'static>,
 }
 
-impl Line {
-    pub fn new(unformatted: String, formatted: Option<String>, style: Style) -> Self {
-        Self {
+impl<'a> Line {
+    /// Create a new Line. Apply the `user_style` to the whole line.
+    /// The formatted string was formatted according to the user's field
+    /// separator.
+    /// The unformatted and formatted strings may both contain ANSI escape
+    /// codes, which will be converted incorporated into `displayed_text`.
+    pub fn new(
+        unformatted_ansi: String,
+        formatted_ansi: Option<String>,
+        user_style: Style,
+    ) -> Result<Self> {
+        let formatted_or_unformatted = formatted_ansi.as_ref().unwrap_or(&unformatted_ansi);
+
+        let displayed_text = Self::format_line_content(formatted_or_unformatted).into_text()?;
+        let displayed = Self::build_displayed_style(&displayed_text, user_style);
+
+        let unformatted = unformatted_ansi.into_text()?.to_unformatted_string();
+
+        Ok(Self {
             unformatted,
-            formatted,
-            style,
-        }
+            displayed,
+            displayed_text,
+        })
     }
 
+    /// Add one space before the line's content to create separation from the
+    /// frame to the left.
+    fn format_line_content(line_content: &str) -> String {
+        format!(" {}", line_content)
+    }
+
+    /// Build the final style of the displayed cell, which consists of the
+    /// displayed text's inherent style and the user style. If any style
+    /// settings overlap, the user style is taken.
+    fn build_displayed_style(displayed_text: &Text<'a>, user_style: Style) -> Cell<'a> {
+        // We don't want to add the user style to the displayed text, so clone.
+        let mut displayed_text = displayed_text.clone();
+        // Merge the style from the displayed text and the user style, and
+        // prioritise the user style.
+        displayed_text.patch_style(user_style);
+        // Also apply user style to whole cell, so areas outside the text but
+        // still inside the cell are also styled.
+        Cell::from(displayed_text).style(user_style)
+    }
+
+    /// Draw the line.
     pub fn draw(&self) -> Cell {
-        let line = self.formatted.as_ref().unwrap_or(&self.unformatted);
-        Cell::from(" ".to_owned() + line).style(self.style)
+        self.displayed.clone()
     }
 
-    pub fn update_style(&mut self, style: Style) {
-        self.style = style;
+    /// Update the style of the whole line.
+    pub fn update_style(&mut self, new_style: Style) {
+        self.displayed = Self::build_displayed_style(&self.displayed_text, new_style);
     }
 
-    pub fn unformatted(&self) -> &String {
+    /// Get the line as a &str.
+    pub fn unformatted_str(&self) -> &str {
         &self.unformatted
+    }
+
+    /// Get the line as an owned String.
+    pub fn unformatted_string(&self) -> String {
+        self.unformatted.to_owned()
+    }
+}
+
+trait ToUnformattedString {
+    /// Extract the unformatted string underlying a `Text` object.
+    fn to_unformatted_string(&self) -> String;
+}
+
+impl<'a> ToUnformattedString for Text<'a> {
+    fn to_unformatted_string(&self) -> String {
+        self.lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .join("\n")
     }
 }

--- a/src/ui/state/lines/selected_lines/mod.rs
+++ b/src/ui/state/lines/selected_lines/mod.rs
@@ -1,0 +1,70 @@
+mod selected_line;
+
+use derive_new::new;
+use ratatui::style::Style;
+
+pub use selected_line::LineSelection;
+
+use self::selected_line::LineSelected;
+
+/// All selected lines.
+#[derive(new)]
+pub struct LineSelections {
+    #[new(default)]
+    selections: Vec<LineSelection>,
+    selected_style: Style,
+    unselected_style: Style,
+}
+
+impl LineSelections {
+    /// Get referencing iterator.
+    pub fn iter(&self) -> impl Iterator<Item = &LineSelection> {
+        self.selections.iter()
+    }
+
+    /// Resize the line selections to `new_len`.
+    pub fn resize(&mut self, new_len: usize) {
+        self.selections.resize(
+            new_len,
+            // If larger, extend vector with unselected lines.
+            LineSelection::new(LineSelected::Unselected, self.unselected_style),
+        )
+    }
+
+    /// Select all lines.
+    pub fn select_all(&mut self) {
+        self.selections.fill(LineSelection::new(
+            LineSelected::Selected,
+            self.selected_style,
+        ));
+    }
+
+    /// Unselect all lines.
+    pub fn unselect_all(&mut self) {
+        self.selections.fill(LineSelection::new(
+            LineSelected::Unselected,
+            self.unselected_style,
+        ));
+    }
+
+    /// Select the line that is at `index` in the vector.
+    pub fn select_at_index(&mut self, index: usize) {
+        if let Some(selection) = self.selections.get_mut(index) {
+            selection.select(self.selected_style);
+        }
+    }
+
+    /// Unselect the line that is at `index` in the vector.
+    pub fn unselect_at_index(&mut self, index: usize) {
+        if let Some(selection) = self.selections.get_mut(index) {
+            selection.unselect(self.unselected_style);
+        }
+    }
+
+    /// Toggle the selection of the line that is at `index` in the vector.
+    pub fn toggle_selection_at_index(&mut self, index: usize) {
+        if let Some(selection) = self.selections.get_mut(index) {
+            selection.toggle_selection(self.selected_style, self.unselected_style);
+        }
+    }
+}

--- a/src/ui/state/lines/selected_lines/selected_line.rs
+++ b/src/ui/state/lines/selected_lines/selected_line.rs
@@ -1,0 +1,66 @@
+use ratatui::{style::Style, widgets::Cell};
+
+/// Stores whether a line is selected or not, and also stores the UI to draw.
+#[derive(Clone)]
+pub struct LineSelection {
+    /// Whether a line is selected or not.
+    line_selected: LineSelected,
+    /// Widget containing the string that will be displayed in the TUI.
+    /// The content string is a single space character.
+    /// The content string is styled/colored if the line is selected.
+    displayed: Cell<'static>,
+}
+
+/// Stores whether a line is selected or not.
+#[derive(Clone)]
+pub enum LineSelected {
+    Unselected,
+    Selected,
+}
+
+impl<'a> LineSelection {
+    /// Create a new line selection.
+    pub fn new(line_selected: LineSelected, style: Style) -> Self {
+        Self {
+            line_selected,
+            displayed: Self::draw_unstyled().style(style),
+        }
+    }
+
+    /// Draw line selection as a styled ratatui widget.
+    pub fn draw(&self) -> Cell {
+        self.displayed.clone()
+    }
+
+    /// Draw a new line selection as an unstyled ratatui widget.
+    fn draw_unstyled() -> Cell<'a> {
+        Cell::from(" ")
+    }
+
+    /// Select the line.
+    pub fn select(&mut self, selected_style: Style) {
+        self.line_selected = LineSelected::Selected;
+        // TODO: remove clone
+        self.displayed = self.displayed.clone().style(selected_style);
+    }
+
+    /// Unselect the line.
+    pub fn unselect(&mut self, unselected_style: Style) {
+        self.line_selected = LineSelected::Unselected;
+        // TODO: remove clone
+        self.displayed = self.displayed.clone().style(unselected_style);
+    }
+
+    /// Toggle the selection of the line.
+    pub fn toggle_selection(&mut self, selected_style: Style, unselected_style: Style) {
+        match self.line_selected {
+            LineSelected::Unselected => self.select(selected_style),
+            LineSelected::Selected => self.unselect(unselected_style),
+        }
+    }
+
+    /// Return whether the line is selected.
+    pub fn is_selected(&self) -> bool {
+        matches!(self.line_selected, LineSelected::Selected)
+    }
+}

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -2,15 +2,17 @@ mod env_variables;
 mod help_menu;
 mod lines;
 
-use std::sync::Arc;
-
-use self::{help_menu::HelpMenu, lines::Lines};
+use self::{
+    help_menu::HelpMenu,
+    lines::{CursorLine, Lines, SelectedLines},
+};
 use crate::config::{Fields, Styles};
 use anyhow::Result;
 use ratatui::{backend::Backend, Frame};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 pub use env_variables::{EnvVariable, EnvVariables};
-use tokio::sync::Mutex;
 
 pub struct State {
     mode: Mode,
@@ -56,8 +58,8 @@ impl State {
         self.lines.update_lines(new_lines)
     }
 
-    pub fn get_cursor_line_and_selected_lines(&mut self) -> Option<(String, String)> {
-        self.lines.get_selected_lines()
+    pub fn get_cursor_line_and_selected_lines(&mut self) -> Option<(CursorLine, SelectedLines)> {
+        self.lines.get_cursor_line_and_selected_lines()
     }
 
     /// Set both the cursor line as well as the selected lines in the UI as
@@ -66,8 +68,8 @@ impl State {
         // TODO: get_selected_lines is sync and computationally intensive, maybe use spawn_blocking
         if let Some((cursor_line, selected_lines)) = self.get_cursor_line_and_selected_lines() {
             let new_env_variables: EnvVariables = [
-                ("line".parse()?, cursor_line),
-                ("lines".parse()?, selected_lines),
+                ("line".parse()?, cursor_line.into()),
+                ("lines".parse()?, selected_lines.into()),
             ]
             .into_iter()
             .collect();


### PR DESCRIPTION
Related to #2.
Previously, ANSI escape sequences in the output lines of the watched command, which are displayed in watchbind, were just printed as is. Now, they are parsed and the color is printed correctly.