### PR TITLE
Fixed environment sharing between executions of subsequent `initial-env` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "indoc",
  "itertools",
  "log",
+ "once_cell",
  "parse-display",
  "ranges",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ranges = "0.3.3"
 tokio = { version = "1.33.0", features = ["full"] }
 futures = "0.3.29"
 ansi-to-tui = "3.1.0"
+once_cell = "1.18.0"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ The environment variable `lines` set to all selected lines, or if none are selec
 All set environment variables `ENV` will be made available in all future spawned commands/processes, including the watched command, any executed subcommands, as well as commands executed in `set-env` operations.
 If multiple lines are selected, they will be separated by newlines in `lines`.
 
+### State management
+
+The `set-env` and `unset-env` operations allow you to manage state through environment variables.
+Additionally, you can use the `initial-env` option to specify a list of `set-env` commands that will be executed **before** the first execution of the watched command.
+This powerful combination allows you to set some initial state with `initial-env`, reference that state directly in the watched command, and update the state with keybindings at runtime with `set-env`.
+
 ### Formatting with Field Separators and Field Selections
 
 `watchbind` supports some extra formatting features reminiscent of the Unix `cut` command:

--- a/src/config/keybindings/operations/mod.rs
+++ b/src/config/keybindings/operations/mod.rs
@@ -33,7 +33,7 @@ impl Operations {
     }
 }
 
-#[derive(IntoIterator, Eq, Ord, PartialEq, PartialOrd, From)]
+#[derive(IntoIterator, Eq, Ord, PartialEq, PartialOrd, From, Clone)]
 pub struct OperationsParsed(#[into_iterator(ref)] Vec<OperationParsed>);
 
 impl TryFrom<Vec<String>> for OperationsParsed {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,7 +28,7 @@ pub struct Config {
     pub keybindings_parsed: KeybindingsParsed,
     pub header_lines: usize,
     pub fields: Fields,
-    pub initial_env_variables: OperationsParsed,
+    pub initial_env_ops: OperationsParsed,
 }
 
 impl Config {
@@ -76,7 +76,7 @@ impl TryFrom<TomlConfig> for Config {
 
         Ok(Self {
             log_file: toml.log_file,
-            initial_env_variables: toml.initial_env_variables.unwrap_or_default().try_into()?,
+            initial_env_ops: toml.initial_env_vars.unwrap_or_default().try_into()?,
             watched_command: match toml.watched_command {
                 Some(command) => command,
                 None => bail!("A command must be provided via command line or config file"),
@@ -100,7 +100,7 @@ pub struct TomlConfig {
     log_file: Option<PathBuf>,
 
     #[serde(rename = "initial-env")]
-    initial_env_variables: Option<Vec<String>>,
+    initial_env_vars: Option<Vec<String>>,
 
     watched_command: Option<String>,
     interval: Option<f64>,
@@ -151,7 +151,7 @@ impl TomlConfig {
     fn merge(self, other: Self) -> Self {
         Self {
             log_file: self.log_file.or(other.log_file),
-            initial_env_variables: self.initial_env_variables.or(other.initial_env_variables),
+            initial_env_vars: self.initial_env_vars.or(other.initial_env_vars),
             watched_command: self.watched_command.or(other.watched_command),
             interval: self.interval.or(other.interval),
             non_cursor_non_header_fg: self
@@ -182,7 +182,7 @@ impl From<ClapConfig> for TomlConfig {
     fn from(clap: ClapConfig) -> Self {
         Self {
             log_file: clap.log_file,
-            initial_env_variables: clap.initial_env_variables,
+            initial_env_vars: clap.initial_env_vars,
             watched_command: clap.watched_command.map(|s| s.join(" ")),
             interval: clap.interval,
             non_cursor_non_header_fg: clap.non_cursor_non_header_fg,
@@ -248,9 +248,9 @@ pub struct ClapConfig {
     #[arg(short, long, value_name = "FILE")]
     log_file: Option<PathBuf>,
 
-    /// Command to watch by executing periodically
+    /// Comman-separated `set-env` operations to execute before first watched command execution
     #[arg(long = "initial-env", value_name = "LIST", value_delimiter = ',')]
-    initial_env_variables: Option<Vec<String>>,
+    initial_env_vars: Option<Vec<String>>,
 
     /// Command to watch by executing periodically
     #[arg(trailing_var_arg(true))]

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -6,8 +6,9 @@ use self::{
     help_menu::HelpMenu,
     lines::{CursorLine, Lines, SelectedLines},
 };
-use crate::config::{Fields, Styles};
-use anyhow::Result;
+use crate::config::{Fields, Operation, Operations, OperationsParsed, Styles};
+use anyhow::{bail, Result};
+use once_cell::sync::Lazy;
 use ratatui::{backend::Backend, Frame};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -51,8 +52,36 @@ impl State {
             self.help_menu.render(frame);
         }
     }
+}
 
-    // API for Lines
+// TODO: replace with std::LazyLock once stable
+static CURSOR_LINE_ENV_VAR: Lazy<EnvVariable> =
+    Lazy::new(|| "line".parse().expect("should be valid env var"));
+static SELECTED_LINES_ENV_VAR: Lazy<EnvVariable> =
+    Lazy::new(|| "lines".parse().expect("should be valid env var"));
+
+// API for Lines
+impl State {
+    /// Set both the cursor line as well as the selected lines in the UI as
+    /// global environment variables for all future processes.
+    pub async fn add_cursor_and_selected_lines_to_env(&mut self) {
+        // TODO: get_selected_lines is sync and computationally intensive, maybe use spawn_blocking
+        if let Some((cursor_line, selected_lines)) = self.get_cursor_line_and_selected_lines() {
+            let new_env_variables: EnvVariables = [
+                ((*CURSOR_LINE_ENV_VAR).clone(), cursor_line.into()),
+                ((*SELECTED_LINES_ENV_VAR).clone(), selected_lines.into()),
+            ]
+            .into_iter()
+            .collect();
+            self.set_envs(new_env_variables).await;
+        };
+    }
+
+    /// Unset the env variables for the cursor line and selected lines.
+    pub async fn remove_cursor_and_selected_lines_from_env(&mut self) {
+        self.unset_env(&CURSOR_LINE_ENV_VAR).await;
+        self.unset_env(&SELECTED_LINES_ENV_VAR).await;
+    }
 
     pub fn update_lines(&mut self, new_lines: String) -> Result<()> {
         self.lines.update_lines(new_lines)
@@ -60,22 +89,6 @@ impl State {
 
     pub fn get_cursor_line_and_selected_lines(&mut self) -> Option<(CursorLine, SelectedLines)> {
         self.lines.get_cursor_line_and_selected_lines()
-    }
-
-    /// Set both the cursor line as well as the selected lines in the UI as
-    /// global environment variables for all future processes.
-    pub async fn add_lines_to_env(&mut self) -> Result<()> {
-        // TODO: get_selected_lines is sync and computationally intensive, maybe use spawn_blocking
-        if let Some((cursor_line, selected_lines)) = self.get_cursor_line_and_selected_lines() {
-            let new_env_variables: EnvVariables = [
-                ("line".parse()?, cursor_line.into()),
-                ("lines".parse()?, selected_lines.into()),
-            ]
-            .into_iter()
-            .collect();
-            self.set_env(new_env_variables).await;
-        };
-        Ok(())
     }
 
     pub fn select(&mut self) {
@@ -119,7 +132,7 @@ impl State {
 
     // API for both Lines and Help Menu
 
-    // TODO: make the "cursor moving" a trait; this is a performance bottleneck, since we always have to match the current mode/state; ideally, we just transition to a state, and then never call any matches until we transition to the next state; the hard part is that we don't have distinct states, since they both still need each other in render all
+    // TODO: make the "cursor moving" a trait/use rust type state pattern; this is a performance bottleneck, since we always have to match the current mode/state; ideally, we just transition to a state, and then never call any matches until we transition to the next state; the hard part is that we don't have distinct states, since they both still need each other in render all
 
     pub fn move_down(&mut self, steps: usize) {
         match self.mode {
@@ -151,18 +164,63 @@ impl State {
 
     // API for environment variables
 
+    /// Generate initial environment variables. The commands to set each
+    /// environment variable are blockingly executed.
+    pub async fn generate_initial_env_vars(
+        &mut self,
+        initial_env_ops_parsed: OperationsParsed,
+    ) -> Result<()> {
+        let initial_env_ops =
+            Operations::from_parsed(initial_env_ops_parsed.clone(), &self.get_env());
+
+        // TODO: consider trying to use async iterators to do this in one iterator pass (instead of the mut hashmap) once stable
+        for (i, op) in initial_env_ops.into_iter().enumerate() {
+            match (i, op) {
+                (_, Operation::SetEnv(env_var, blocking_cmd)) => {
+                    let cmd_output = blocking_cmd.execute().await?;
+                    self.set_env(env_var, cmd_output).await;
+                }
+                (op_index, _) => {
+                    // Delay retrieval of printable `OperationParsed` until error case
+                    // => improve performance for correct use of "set-env".
+                    let other_op = initial_env_ops_parsed
+                        .into_iter()
+                        .nth(op_index)
+                        .expect("length of `Operations` and `OperationsParsed` should be same");
+                    bail!("Only `set-env` operations allowed during initial environment variable generation, but received invalid operation: {}", other_op);
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub fn get_env(&self) -> Arc<Mutex<EnvVariables>> {
         self.env_variables.clone()
     }
 
-    pub async fn set_env(&mut self, new_env_variables: EnvVariables) {
+    /// Set environment variable `env_var` to `value`.
+    pub async fn set_env(&mut self, env_var: EnvVariable, value: String) {
+        let mut env_variables = self.env_variables.lock().await;
+        env_variables.set_env(env_var, value);
+    }
+
+    pub async fn set_envs(&mut self, new_env_variables: EnvVariables) {
         let mut env_variables = self.env_variables.lock().await;
         env_variables.merge_new_envs(new_env_variables);
     }
 
-    pub async fn unset_env(&mut self, env: &EnvVariable) {
+    /// Unset an environment variable.
+    pub async fn unset_env(&mut self, env_var: &EnvVariable) {
         let mut env_variables = self.env_variables.lock().await;
-        env_variables.unset_env(env)
+        env_variables.unset_env(env_var)
+    }
+
+    /// Unset multiple environment variables.
+    pub async fn unset_envs(&mut self, env_vars: &[EnvVariable]) {
+        let mut env_variables = self.env_variables.lock().await;
+        for env in env_vars {
+            env_variables.unset_env(env);
+        }
     }
 
     pub async fn read_into_env(&mut self, _env: &EnvVariable) {


### PR DESCRIPTION
Previously, each `set-env` command that was executed as part of the `initial-env` environment variable generation (so before the watched command has been executed, and before the TUI has even been painted) had a separate environment from all other `set-env` commands during initial generation. This meant that an env variable set in the first `set-env` command would not be available in the execution of the second `set-env`, even though that would be expected. For example:
```sh
watchbind --initial-env "set-env one -- printf test" --initial-env "set-env two -- printf \${one}2" -- echo \$one \$two
```
would not display the expected `test test2`, but instead `test 2` because the env variable `$one`, which was set in the first `initial-env` command, was not made available inside the second `initial-env`.
This has now been fixed.