### PR TITLE
fix: 'select-all' only selects non-header lines

### DIFF
--- a/src/ui/state/lines/mod.rs
+++ b/src/ui/state/lines/mod.rs
@@ -46,7 +46,11 @@ impl Lines {
     pub fn new(fields: Fields, styles: Styles, header_lines: usize) -> Self {
         Self {
             lines: vec![],
-            line_selections: LineSelections::new(styles.selected, styles.non_cursor_non_header),
+            line_selections: LineSelections::new(
+                styles.selected,
+                styles.non_cursor_non_header,
+                header_lines,
+            ),
             fields,
             cursor_index: None,
             styles,

--- a/src/ui/state/lines/selected_lines/mod.rs
+++ b/src/ui/state/lines/selected_lines/mod.rs
@@ -13,6 +13,7 @@ pub struct LineSelections {
     selections: Vec<LineSelection>,
     selected_style: Style,
     unselected_style: Style,
+    index_after_header_lines: usize,
 }
 
 impl LineSelections {
@@ -32,10 +33,13 @@ impl LineSelections {
 
     /// Select all lines.
     pub fn select_all(&mut self) {
-        self.selections.fill(LineSelection::new(
-            LineSelected::Selected,
-            self.selected_style,
-        ));
+        self.selections
+            .iter_mut()
+            // Don't select the header lines.
+            .skip(self.index_after_header_lines)
+            .for_each(|selection| {
+                *selection = LineSelection::new(LineSelected::Selected, self.selected_style);
+            });
     }
 
     /// Unselect all lines.


### PR DESCRIPTION
Fixes #79.