### PR TITLE
docs: stylized possible values in cli help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "ansi-str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
 name = "ansi-to-tui"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,16 @@ dependencies = [
  "nom",
  "ratatui",
  "thiserror",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+dependencies = [
+ "nom",
+ "vte",
 ]
 
 [[package]]
@@ -110,6 +129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +166,12 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytes"
@@ -293,6 +324,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -557,6 +594,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "papergrid"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +684,30 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -909,6 +989,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tabwriter"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1188,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,13 +1229,16 @@ dependencies = [
  "itertools",
  "log",
  "once_cell",
+ "owo-colors",
  "parse-display",
  "ranges",
  "ratatui",
  "serde",
  "simplelog",
  "strum",
+ "tabled",
  "tabwriter",
+ "terminal_size",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ futures = "0.3.29"
 ansi-to-tui = "3.1.0"
 once_cell = "1.18.0"
 strum = { version = "0.25.0", features = ["derive"] }
+tabled = { version = "0.14.0", features = ["color"] }
+terminal_size = "0.3.0"
+owo-colors = "3.5.0"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/src/config/keybindings/key.rs
+++ b/src/config/keybindings/key.rs
@@ -3,10 +3,9 @@ use crossterm::event::{
     KeyCode as CrosstermKeyCode, KeyEvent as CrosstermKeyEvent,
     KeyModifiers as CrosstermKeyModifiers,
 };
-use itertools::Itertools;
 use parse_display::{Display, FromStr};
 use std::{fmt, str};
-use strum::{EnumIter, EnumMessage, EnumProperty, IntoEnumIterator};
+use strum::{EnumIter, EnumMessage, EnumProperty};
 
 /// The specific combinations of modifiers and key codes that we allow/handle.
 #[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Clone, Debug)]
@@ -29,7 +28,6 @@ pub struct KeyEvent {
     FromStr,
     // For displaying all possible variants
     EnumIter,
-    EnumMessage,
     EnumProperty,
 )]
 #[display(style = "lowercase")]
@@ -61,7 +59,6 @@ pub enum KeyModifier {
     // For displaying all possible variants
     EnumIter,
     EnumMessage,
-    EnumProperty,
 )]
 #[display(style = "lowercase")]
 pub enum KeyCode {
@@ -183,36 +180,6 @@ impl TryFrom<CrosstermKeyCode> for KeyCode {
             // TODO: shouldn't use debug output for display output
             _ => bail!("Invalid key code: {:?}", value),
         })
-    }
-}
-
-/// Get string list of all possible values of `T`.
-fn get_possible_values<T>() -> String
-where
-    T: IntoEnumIterator + EnumMessage + EnumProperty + fmt::Display,
-{
-    T::iter()
-        // TODO: replace with strum's get_bool once available
-        // Hide variants configured to be hidden.
-        .filter(|variant| !matches!(variant.get_str("Hidden"), Some("true")))
-        // Use strum's `message` if available, otherwise use `to_string`.
-        .map(|variant| {
-            variant
-                .get_message()
-                .map(str::to_owned)
-                .unwrap_or_else(|| variant.to_string())
-        })
-        .join(", ")
-}
-
-impl KeyEvent {
-    /// Get string help menu of all possible values of `KeyCode` and
-    /// `KeyModifier`.
-    pub fn all_possible_values() -> (String, String) {
-        (
-            get_possible_values::<KeyCode>(),
-            get_possible_values::<KeyModifier>(),
-        )
     }
 }
 

--- a/src/config/keybindings/operations/operation.rs
+++ b/src/config/keybindings/operations/operation.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use parse_display::{Display, FromStr};
 use std::str;
 use std::sync::Arc;
-use strum::{EnumIter, EnumMessage, EnumProperty};
+use strum::{EnumIter, EnumMessage};
 use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::Mutex;
 
@@ -28,7 +28,6 @@ use tokio::sync::Mutex;
     // For displaying all possible variants
     EnumIter,
     EnumMessage,
-    EnumProperty,
 )]
 #[display(style = "kebab-case")]
 pub enum OperationParsed {

--- a/src/config/possible_enum_values.rs
+++ b/src/config/possible_enum_values.rs
@@ -1,0 +1,146 @@
+use itertools::Itertools;
+use std::{fmt, marker::PhantomData};
+use strum::{EnumMessage, EnumProperty, IntoEnumIterator};
+
+/// A helper to retrieve all possible variants/values of an enum. Supports
+/// providing custom names for specific variants and hiding specific variants.
+pub struct PossibleEnumValues<E, N = NoCustomVariantNames, F = NoHidden> {
+    enum_type: PhantomData<E>,
+    support_custom_variant_names: PhantomData<N>,
+    support_hiding_variants: PhantomData<F>,
+}
+
+// Type-States
+
+#[derive(Clone)]
+pub struct NoCustomVariantNames;
+#[derive(Clone)]
+pub struct CustomVariantNames;
+
+#[derive(Clone)]
+pub struct NoHidden;
+#[derive(Clone)]
+pub struct Hidden;
+
+// Builder pattern
+
+impl<E> PossibleEnumValues<E> {
+    /// Creates a new instance of the `PossibleEnumValues` builder.
+    pub fn new() -> PossibleEnumValues<E, NoCustomVariantNames, NoHidden> {
+        PossibleEnumValues {
+            enum_type: PhantomData,
+            support_custom_variant_names: PhantomData,
+            support_hiding_variants: PhantomData,
+        }
+    }
+}
+
+impl<E, N, H> PossibleEnumValues<E, N, H> {
+    /// Support overriding default variant names with custom names with:
+    /// `#[strum(message = "<custom-name>")]`.
+    pub fn custom_names(self) -> PossibleEnumValues<E, CustomVariantNames, H> {
+        PossibleEnumValues {
+            enum_type: self.enum_type,
+            support_custom_variant_names: PhantomData,
+            support_hiding_variants: self.support_hiding_variants,
+        }
+    }
+
+    /// Support hiding variants with:
+    /// `#[strum(props(Hidden = "true"))]`.
+    pub fn hidden(self) -> PossibleEnumValues<E, N, Hidden> {
+        PossibleEnumValues {
+            enum_type: self.enum_type,
+            support_custom_variant_names: self.support_custom_variant_names,
+            support_hiding_variants: PhantomData,
+        }
+    }
+}
+
+// Hide configured variants
+
+impl<E, N> PossibleEnumValues<E, N, Hidden> {
+    /// Returns `true` if a variant should be shown, and `false` if it should
+    /// be hidden.
+    fn should_be_shown(variant: &E) -> bool
+    where
+        E: EnumProperty,
+    {
+        // TODO: replace with strum's get_bool once available
+        !matches!(variant.get_str("Hidden"), Some("true"))
+    }
+}
+
+// Get variant as string
+
+impl<E, H> PossibleEnumValues<E, NoCustomVariantNames, H> {
+    /// Get the string representation of an enum variant. Use `to_string`.
+    fn get_variant_as_string(variant: E) -> String
+    where
+        E: fmt::Display,
+    {
+        variant.to_string()
+    }
+}
+
+impl<E, H> PossibleEnumValues<E, CustomVariantNames, H> {
+    /// Get the string representation of an enum variant. Use strum's `message`
+    /// if available, otherwise use `to_string`.
+    fn get_variant_as_string(variant: E) -> String
+    where
+        E: EnumMessage + fmt::Display,
+    {
+        variant
+            .get_message()
+            .map(str::to_owned)
+            .unwrap_or_else(|| variant.to_string())
+    }
+}
+
+// Get final string list of variants
+
+impl<E> PossibleEnumValues<E, NoCustomVariantNames, NoHidden> {
+    /// Get a string list of all possible variants for the enum.
+    pub fn get(self) -> String
+    where
+        E: IntoEnumIterator + fmt::Display,
+    {
+        E::iter().map(Self::get_variant_as_string).join(", ")
+    }
+}
+
+impl<E> PossibleEnumValues<E, CustomVariantNames, NoHidden> {
+    /// Get a string list of all possible variants for the enum.
+    pub fn get(self) -> String
+    where
+        E: IntoEnumIterator + EnumMessage + fmt::Display,
+    {
+        E::iter().map(Self::get_variant_as_string).join(", ")
+    }
+}
+
+impl<E> PossibleEnumValues<E, NoCustomVariantNames, Hidden> {
+    /// Get a string list of all possible variants for the enum.
+    pub fn get(self) -> String
+    where
+        E: IntoEnumIterator + EnumProperty + fmt::Display,
+    {
+        E::iter()
+            .filter(Self::should_be_shown)
+            .map(Self::get_variant_as_string)
+            .join(", ")
+    }
+}
+
+impl<E> PossibleEnumValues<E, CustomVariantNames, Hidden> {
+    /// Get a string list of all possible variants for the enum.
+    pub fn _get(self) -> String
+    where
+        E: IntoEnumIterator + EnumMessage + EnumProperty + fmt::Display,
+    {
+        E::iter()
+            .filter(Self::should_be_shown)
+            .map(Self::get_variant_as_string)
+            .join(", ")
+    }
+}


### PR DESCRIPTION
Improved the overall styling
- Format possible values as a table with two columns, to ensure possible values don't overflow out of their column for nicer wrapping.
- Every possible COLOR value is now colored in its color using ANSI escape codes.
- Provide a nice API for getting all `PossibleEnumValues`, which leads to less `strum` derives being necessary for enums that don't need custom names for specific variants or hidden variants.